### PR TITLE
using 'ukc-vhsm' instead of 'ukc-server' which does not exist

### DIFF
--- a/casp-docker/docker-compose.yml
+++ b/casp-docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   ukc-ep:
-    image: "unboundukc/ukc-server:${CASP_VERSION:-latest}"
+    image: "unboundukc/ukc-vhsm:${CASP_VERSION:-latest}"
     container_name: ukc-ep
     restart: always
     ports:
@@ -14,13 +14,13 @@ services:
       UKC_PARTITION: 'casp'
       UKC_PARTITION_USER_PASSWORD: 'Unbound1!'
   ukc-partner:
-    image: "unboundukc/ukc-server:${CASP_VERSION:-latest}"
+    image: "unboundukc/ukc-vhsm:${CASP_VERSION:-latest}"
     container_name: ukc-partner
     restart: always
     command: ["partner", "ukc-ep", "ukc-aux"]
     hostname: ukc-partner
   ukc-aux:
-    image: "unboundukc/ukc-server:${CASP_VERSION:-latest}"
+    image: "unboundukc/ukc-vhsm:${CASP_VERSION:-latest}"
     container_name: ukc-aux
     restart: always
     command: ["aux", "ukc-ep", "ukc-partner"]


### PR DESCRIPTION
Using 'ukc-vhsm' as UKC docker image works properly and is on par with [Unbound-NextGen-vHSM-Interactive-Demo](https://github.com/unbound-tech/Unbound-NextGen-vHSM-Interactive-Demo).