### PR TITLE
ensure services startup order

### DIFF
--- a/casp-docker/docker-compose.yml
+++ b/casp-docker/docker-compose.yml
@@ -65,7 +65,7 @@ services:
       CASP_ACCOUNT: 'CASP'
     entrypoint: /bin/sh
     # Waiting for 'ukc-ep' to be healthy to avoid issues
-    command: -c 'while [[ "$$(curl -s -k -o /dev/null -w ''%{http_code}'' https://$${UKC_EP}:8443/api/v1/health)" != "200" ]]; do sleep 5; done; /unbound/start_casp.sh start'
+    command: -c 'while [[ "$$(curl -s -k -o /dev/null -w ''%{http_code}'' https://$${UKC_EP}:$${UKC_PORT}/api/v1/health)" != "200" ]]; do sleep 5; done; /unbound/start_casp.sh start'
     depends_on:
       - "ukc-ep"
       - "ukc-partner"

--- a/casp-docker/docker-compose.yml
+++ b/casp-docker/docker-compose.yml
@@ -63,6 +63,9 @@ services:
       BLOCKSET_TOKEN: ${BLOCKSET_TOKEN}
       CASP_SO_PASSWORD: ${CASP_SO_PASSWORD:-Unbound1!}
       CASP_ACCOUNT: 'CASP'
+    entrypoint: /bin/sh
+    # Waiting for 'ukc-ep' to be healthy to avoid issues
+    command: -c 'while [[ "$$(curl -s -k -o /dev/null -w ''%{http_code}'' https://$${UKC_EP}:8443/api/v1/health)" != "200" ]]; do sleep 5; done; /unbound/start_casp.sh start'
     depends_on:
       - "ukc-ep"
       - "ukc-partner"
@@ -78,5 +81,8 @@ services:
       CASP_SO_PASSWORD: ${CASP_SO_PASSWORD:-Unbound1!}
       CASP_ACCOUNT: 'CASP'
       BOT_KS_PASSWORD: ${CASP_SO_PASSWORD:-Unbound1!}
+    entrypoint: /bin/sh
+    # Waiting for 'casp' to be healthy to avoid issues
+    command: -c 'while [[ "$$(curl -s -k -o /dev/null -w ''%{http_code}'' https://$${CASP}:443/casp/api/v1.0/mng/status)" != "200" ]]; do sleep 5; done; /start_bot.sh start'
     depends_on:
       - "casp"


### PR DESCRIPTION
Since the startup script of 'casp' service only waits for 'ukc-ep' service to start listening on 'https://${UKC_EP}:${UKC_PORT}/api/v1/health' and does not verifiy that it is actually 'healthy'  by checking the return code - we suspect that this sometimes results in startup issues.
Same thing for startup script of 'casp-bot' service and 'https://$${CASP}:443/casp/api/v1.0/mng/status' healthcheck endpoint for casp.

Since using 'depends_on' in condition form has been deprecated in 3+, we suggest to use one of the [recommended alternative approaches](https://docs.docker.com/compose/startup-order/) or simply amend the startup scripts accordingly. 
Since we preferred not to override the scripts, we added the following checks to start commands of both 'casp' and 'casp-bot'. No startup issues were reported since.